### PR TITLE
block system events for brightness/volume/media/lock keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,3 @@ accessibility features. These are used to intercept keyboard events.
 
 Although there are a couple existing applications that provide this functionality, none of them were Open Source and I 
 didn't want to give elevated permissions to those apps if I could not verify the source code.
-
-## Known limitations
-
-- Media keys (e.g., volume keys and play/pause buttons) and the power button (lock) will still function even while the keyboard block is active.
-- If you press the power button and your system goes to the lock screen and input is not blocked while on the lock screen


### PR DESCRIPTION
Addresses the known limitation where special keys like for brightness adjustment, media keys, and the power/lock button were not being actively blocked. This PR makes sure these system events are also suppressed.